### PR TITLE
Update jQuery calls to use jQuery rather than $

### DIFF
--- a/lib/ToastMessage/jQueryMixin.js
+++ b/lib/ToastMessage/jQueryMixin.js
@@ -72,7 +72,7 @@ module.exports = {
   },
 
   _get_$_node:function () {
-    return $(this.getDOMNode());
+    return jQuery(this.getDOMNode());
   },
 
   _set_interval_id:function (intervalId) {

--- a/src/ToastMessage/jQueryMixin.js
+++ b/src/ToastMessage/jQueryMixin.js
@@ -72,7 +72,7 @@ module.exports = {
   },
 
   _get_$_node () {
-    return $(this.getDOMNode());
+    return jQuery(this.getDOMNode());
   },
 
   _set_interval_id (intervalId) {


### PR DESCRIPTION
A small change to avoid assuming $ is mapped to jQuery in the global namespace.
