### PR TITLE
fix (jQueryMixin): reset state.isHiding on MouseEnter event

### DIFF
--- a/src/ToastMessage/jQueryMixin.js
+++ b/src/ToastMessage/jQueryMixin.js
@@ -44,6 +44,7 @@ module.exports = {
   handleMouseEnter () {
     clearTimeout(this.state.intervalId);
     this._set_interval_id(null);
+    this._set_is_hiding(false);
 
     call_show_method(this._get_$_node().stop(true, true), this.props);
   },
@@ -78,6 +79,12 @@ module.exports = {
   _set_interval_id (intervalId) {
     this.setState({
       intervalId
+    });
+  },
+
+  _set_is_hiding (isHiding) {
+    this.setState({
+      isHiding
     });
   }
 };


### PR DESCRIPTION
The state.isHiding wasn't reset after a MouseEnter on a toast. This blocks then the entire hide functionality.