### PR TITLE
fix (ToastMessage, ToastContainer): using custom prop to identify toast

### DIFF
--- a/src/ToastContainer.js
+++ b/src/ToastContainer.js
@@ -69,11 +69,13 @@ module.exports = React.createClass({
       }
     }
     var key = state.toastId++;
+    var toastId = key;
     var newToast = update(optionsOverride || {}, {
       $merge: {
         type,
         title,
         message,
+        toastId,
         key,
         ref: `toasts__${ key }`,
         handleOnClick: this._handle_toast_on_click,
@@ -99,10 +101,10 @@ module.exports = React.createClass({
     event.stopPropagation();
   },
 
-  _handle_toast_remove (key) {
+  _handle_toast_remove (toastId) {
     var {state} = this;
     state.toasts[`${ this.props.newestOnTop ? "reduceRight" : "reduce" }`]((found, toast, index) => {
-      if (found || toast.key !== key) {
+      if (found || toast.toastId !== toastId) {
         return false;
       }
       this.setState(update(state, {

--- a/src/ToastMessage/index.js
+++ b/src/ToastMessage/index.js
@@ -40,7 +40,7 @@ var ToastMessageSpec = {
 
   _handle_remove () {
     var {props} = this;
-    props.handleRemove(props.key);
+    props.handleRemove(props.toastId);
   },
 
   _render_close_button (props) {


### PR DESCRIPTION
key was removed from props in React v0.12 so it can't be used as a toast reference. More details here: http://facebook.github.io/react/blog/2014/10/16/react-v0.12-rc1.html#breaking-change-key-and-ref-removed-from-this.props