### PR TITLE
Return ToastMessage ref on create

### DIFF
--- a/lib/ToastContainer.js
+++ b/lib/ToastContainer.js
@@ -54,22 +54,22 @@ var ToastContainer = function (_Component) {
   _createClass(ToastContainer, [{
     key: "error",
     value: function error(message, title, optionsOverride) {
-      this._notify(this.props.toastType.error, message, title, optionsOverride);
+      return this._notify(this.props.toastType.error, message, title, optionsOverride);
     }
   }, {
     key: "info",
     value: function info(message, title, optionsOverride) {
-      this._notify(this.props.toastType.info, message, title, optionsOverride);
+      return this._notify(this.props.toastType.info, message, title, optionsOverride);
     }
   }, {
     key: "success",
     value: function success(message, title, optionsOverride) {
-      this._notify(this.props.toastType.success, message, title, optionsOverride);
+      return this._notify(this.props.toastType.success, message, title, optionsOverride);
     }
   }, {
     key: "warning",
     value: function warning(message, title, optionsOverride) {
-      this._notify(this.props.toastType.warning, message, title, optionsOverride);
+      return this._notify(this.props.toastType.warning, message, title, optionsOverride);
     }
   }, {
     key: "clear",
@@ -107,6 +107,7 @@ var ToastContainer = function (_Component) {
       }
       var key = this.state.toastId++;
       var toastId = key;
+      var ref = "toasts__" + key
       var newToast = (0, _reactAddonsUpdate2.default)(optionsOverride, {
         $merge: {
           type: type,
@@ -114,7 +115,7 @@ var ToastContainer = function (_Component) {
           message: message,
           toastId: toastId,
           key: key,
-          ref: "toasts__" + key,
+          ref: ref,
           handleOnClick: function handleOnClick(e) {
             if ("function" === typeof optionsOverride.handleOnClick) {
               optionsOverride.handleOnClick();
@@ -131,6 +132,8 @@ var ToastContainer = function (_Component) {
         previousMessage: { $set: message }
       });
       this.setState(nextState);
+
+      return ref;
     }
   }, {
     key: "_handle_toast_on_click",


### PR DESCRIPTION
This will cause the different toast display methods to return their ref name so that the toast component can be more easily accessed and/or manipulated. This is useful when you need to have an external process hide a specific toast. 