### PR TITLE
Handles "prevent duplicates" issue

### DIFF
--- a/lib/ToastContainer.js
+++ b/lib/ToastContainer.js
@@ -86,7 +86,6 @@ var ToastContainer = function (_Component) {
       var _this3 = this;
 
       var optionsOverride = arguments.length <= 3 || arguments[3] === undefined ? {} : arguments[3];
-      
       if (this.props.preventDuplicates) {
         if (this.state.previousMessage === message) {
           return;

--- a/lib/ToastContainer.js
+++ b/lib/ToastContainer.js
@@ -86,7 +86,7 @@ var ToastContainer = function (_Component) {
       var _this3 = this;
 
       var optionsOverride = arguments.length <= 3 || arguments[3] === undefined ? {} : arguments[3];
-
+      
       if (this.props.preventDuplicates) {
         if (this.state.previousMessage === message) {
           return;
@@ -133,6 +133,7 @@ var ToastContainer = function (_Component) {
     key: "_handle_toast_remove",
     value: function _handle_toast_remove(toastId) {
       var _this4 = this;
+      this.state.previousMessage ='';
 
       var operationName = "" + (this.props.newestOnTop ? "reduceRight" : "reduce");
       this.state.toasts[operationName](function (found, toast, index) {
@@ -185,7 +186,7 @@ ToastContainer.defaultProps = {
   },
   id: "toast-container",
   toastMessageFactory: _react2.default.createFactory(_ToastMessage2.default),
-  preventDuplicates: false,
+  preventDuplicates: true,
   newestOnTop: true,
   onClick: function onClick() {}
 };


### PR DESCRIPTION
The code for some reason doesn't seem to accept the "preventDuplicates" value, even if its passed in the toastr options. The updated code always sets preventDuplicates to true. 

Functionality:
When there is a toastr message, there will be no duplicate toastr messages called until the toastr message closes.