### PR TITLE
feat(preventDuplicates): Changed to list

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
   "dependencies": {
     "classnames": "^2.2.3",
     "element-class": "^0.2.2",
+    "lodash": "^4.13.1",
     "react-addons-update": "^0.14.0 || ^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0"
   }

--- a/src/ToastContainer.js
+++ b/src/ToastContainer.js
@@ -74,7 +74,7 @@ export default class ToastContainer extends Component {
 
   _notify(type, message, title, optionsOverride = {}) {
     if (this.props.preventDuplicates) {
-      if (_.includes(this.state.messageList, message) {
+      if (_.includes(this.state.messageList, message)) {
         return;
       }
     }

--- a/src/ToastContainer.js
+++ b/src/ToastContainer.js
@@ -12,7 +12,7 @@ import {
   default as ToastMessage,
 } from "./ToastMessage";
 
-import _ from "lodash"
+import _ from "lodash";
 
 export default class ToastContainer extends Component {
 
@@ -47,7 +47,7 @@ export default class ToastContainer extends Component {
   state = {
     toasts: [],
     toastId: 0,
-    messageList: []
+    messageList: [],
   };
 
   error(message, title, optionsOverride) {
@@ -132,7 +132,7 @@ export default class ToastContainer extends Component {
       }
       this.setState(update(this.state, {
         toasts: { $splice: [[index, 1]] },
-        messageList: { $splice: [[index, 1]] }
+        messageList: { $splice: [[index, 1]] },
       }));
       return true;
     }, false);

--- a/src/ToastContainer.js
+++ b/src/ToastContainer.js
@@ -12,6 +12,8 @@ import {
   default as ToastMessage,
 } from "./ToastMessage";
 
+import _ from "lodash"
+
 export default class ToastContainer extends Component {
 
   static propTypes = {
@@ -36,8 +38,8 @@ export default class ToastContainer extends Component {
       warning: `warning`,
     },
     id: `toast-container`,
-    toastMessageFactory: React.createFactory(ToastMessage),
-    preventDuplicates: false,
+    toastMessageFactory: React.createFactory(ToastMessage.animation),
+    preventDuplicates: true,
     newestOnTop: true,
     onClick() {},
   };
@@ -45,7 +47,7 @@ export default class ToastContainer extends Component {
   state = {
     toasts: [],
     toastId: 0,
-    previousMessage: null,
+    messageList: []
   };
 
   error(message, title, optionsOverride) {
@@ -72,7 +74,7 @@ export default class ToastContainer extends Component {
 
   _notify(type, message, title, optionsOverride = {}) {
     if (this.props.preventDuplicates) {
-      if (this.state.previousMessage === message) {
+      if (_.includes(this.state.messageList, message) {
         return;
       }
     }
@@ -99,9 +101,13 @@ export default class ToastContainer extends Component {
       [`${this.props.newestOnTop ? `$unshift` : `$push`}`]: [newToast],
     };
 
+    const messageOperation = {
+      [`${this.props.newestOnTop ? `$unshift` : `$push`}`]: [message],
+    };
+
     const nextState = update(this.state, {
       toasts: toastOperation,
-      previousMessage: { $set: message },
+      messageList: messageOperation,
     });
     this.setState(nextState);
   }
@@ -116,6 +122,9 @@ export default class ToastContainer extends Component {
   }
 
   _handle_toast_remove(toastId) {
+    if (this.props.preventDuplicates) {
+      this.state.previousMessage = ``;
+    }
     const operationName = `${this.props.newestOnTop ? `reduceRight` : `reduce`}`;
     this.state.toasts[operationName]((found, toast, index) => {
       if (found || toast.toastId !== toastId) {
@@ -123,6 +132,7 @@ export default class ToastContainer extends Component {
       }
       this.setState(update(this.state, {
         toasts: { $splice: [[index, 1]] },
+        messageList: { $splice: [[index, 1]] }
       }));
       return true;
     }, false);


### PR DESCRIPTION
The prevent duplicates feature works by checking the previously rendered message with the current message and avoids duplicates. There is a test case which will not pass in the following situation - success('hello') _--- followed by -->_ success('bye') _--- followed by-->_ success('hello'). The last "hello" should not render until the previous "hello" has unmounted.

Now, the code maintains a list of messages that are currently being rendered. This makes sure that aforementioned issue doesn't happen.