### PR TITLE
Replace React.PropTypes with PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "classnames": "^2.2.5",
     "element-class": "^0.2.2",
     "lodash": "^4.16.1",
+    "prop-types": "^15.5.8",
     "react-addons-update": "^0.14.0 || ^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0"
   }

--- a/src/lib/ToastContainer.js
+++ b/src/lib/ToastContainer.js
@@ -3,8 +3,11 @@ import _ from "lodash";
 import {
   default as React,
   Component,
-  PropTypes,
 } from "react";
+
+import {
+  PropTypes
+} from 'prop-types';
 
 import {
   default as update,

--- a/src/lib/ToastContainer.js
+++ b/src/lib/ToastContainer.js
@@ -6,7 +6,7 @@ import {
 } from "react";
 
 import {
-  PropTypes
+  PropTypes,
 } from 'prop-types';
 
 import {


### PR DESCRIPTION
This should silence warnings being generated by react-toastr in latest react versions.