### PR TITLE
Move react-dom to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "standard-version": "^4.2.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.0 || ^15.0.0",
+    "react-dom": "^15.6.1"
   },
   "dependencies": {
     "classnames": "^2.2.5",
@@ -88,7 +89,6 @@
     "element-class": "^0.2.2",
     "immutability-helper": "^2.3.1",
     "lodash": "^4.17.4",
-    "prop-types": "^15.5.10",
-    "react-dom": "^15.6.1"
+    "prop-types": "^15.5.10"
   }
 }


### PR DESCRIPTION
Makes react-dom a peer dependency, per the discussion in #33 . Having multiple copies of react-dom installed adds significant bloat - this should mitigate that.